### PR TITLE
Added paint stripe layers to front and rear faces. Blends nicely with pa...

### DIFF
--- a/labels/init.lua
+++ b/labels/init.lua
@@ -4,7 +4,7 @@
 minetest.register_node(":streets:asphalt_sideline",{
 	description = streets.S("Asphalt with sideline"),
 	groups = {cracky=3},
-	tiles = {"streets_asphalt.png^streets_asphalt_side.png","streets_asphalt.png"},
+	tiles = {"streets_asphalt.png^streets_asphalt_side.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png^streets_asphalt_side.png^[transformR180","streets_asphalt.png^streets_asphalt_side.png"},
 	paramtype2 = "facedir"
 })
 minetest.register_alias("streets:asphalt_side","streets:asphalt_sideline")
@@ -20,7 +20,7 @@ minetest.register_craft({
 minetest.register_node(":streets:asphalt_solid_line",{
 	description = streets.S("Asphalt with solid line"),
 	groups = {cracky=3},
-	tiles = {"streets_asphalt.png^streets_asphalt_solid_line.png","streets_asphalt.png"},
+	tiles = {"streets_asphalt.png^streets_asphalt_solid_line.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png^streets_asphalt_solid_line.png","streets_asphalt.png^streets_asphalt_solid_line.png"},
 	paramtype2 = "facedir"
 })
 minetest.register_alias("streets:asphalt_middle","streets:asphalt_solid_line")
@@ -36,7 +36,7 @@ minetest.register_craft({
 minetest.register_node(":streets:asphalt_dashed_line",{
 	description = streets.S("Asphalt with dashed line"),
 	groups = {cracky=3},
-	tiles = {"streets_asphalt.png^streets_asphalt_dashed_line.png","streets_asphalt.png"},
+	tiles = {"streets_asphalt.png^streets_asphalt_dashed_line.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png","streets_asphalt.png^streets_asphalt_dashed_line.png","streets_asphalt.png^streets_asphalt_dashed_line.png"},
 	paramtype2 = "facedir"
 })
 minetest.register_alias("streets:asphalt_middle_dashed","streets:asphalt_dashed_line")


### PR DESCRIPTION
...inted slabs.

When building a gradually sloping road using slabs, the front faces of the full sized "painted" nodes are exposed and don't look very good when facing the uphill side of your road. I simply added existing "paint" textures to front and rear faces of three nodes. The sideline had to be rotated 180 on the rear of one node. I think it looks polished and less confusing when using the road.
Attached is before and after, showing the difference. Hope you will consider pulling.
![streets_faces_mod](https://cloud.githubusercontent.com/assets/9083807/4569941/a6ba3464-4f53-11e4-81a8-7ae7e2e4d498.png)
