### PR TITLE
Bollard is now up when having no signal.

### DIFF
--- a/streets_bollards/init.lua
+++ b/streets_bollards/init.lua
@@ -32,10 +32,10 @@ minetest.register_node("streets:bollard_driver", {
 	mesecons = {
 			effector = {
 				rules = mesecon.rules.default,
-				action_on = function (pos, node)
+				action_off = function (pos, node)
 					toggle_bollard(vector.add(pos, vector.new(0, 1, 0)), node, nil, nil, {type = "node", under = vector.add(pos, vector.new(0, -1, 0)), above = vector.add(pos, vector.new(0, 1, 0))},"up")
 				end,
-				action_off = function (pos, node)
+				action_on = function (pos, node)
 					toggle_bollard(vector.add(pos, vector.new(0, 1, 0)), node, nil, nil, {type = "node", under = vector.add(pos, vector.new(0, -1, 0)), above = vector.add(pos, vector.new(0, 1, 0))},"down")
 				end
 	}}


### PR DESCRIPTION
This seems more logical to me, as the bollard is up most of the time.
Work well together with player detectors.
@cheapie: Please review this.